### PR TITLE
Fix for DeprecationWarning (django 1.3+)

### DIFF
--- a/src/picklefield/fields.py
+++ b/src/picklefield/fields.py
@@ -108,7 +108,7 @@ class PickledObjectField(models.Field):
                     raise
         return value
 
-    def get_db_prep_value(self, value, connection=None):
+    def get_db_prep_value(self, value, connection=None, prepared=None):
         """
         Pickle and b64encode the object, optionally compressing it.
 


### PR DESCRIPTION
The latest release had a partial fix for the deprecation warnings due to multi-db: but one was missing.

This patch fixes that. I think I'm correct in assuming that we don't care what the connection that was passed in is, so we can safely ignore it?
