### PR TITLE
Favor the built-in json module.

### DIFF
--- a/src/picklefield/compat.py
+++ b/src/picklefield/compat.py
@@ -9,7 +9,10 @@ try:
     from cPickle import loads, dumps # cpython 2.x
 except ImportError:
     from pickle import loads, dumps # cpython 3.x, other interpreters
+
+# django 1.6 will deprecate django.utils.simple_json
 try:
-    from django.utils import simplejson as json
-except ImportError:
     import json
+except ImportError:
+    from django.utils import simplejson as json
+    


### PR DESCRIPTION
The django's bundled simplejson module is pending deprecation as of version 1.5 and will be totally removed in 1.7. We should favor the built-in version in all cases.
