### PR TITLE
Added Django 1.9, 1.10 to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ language: python
 env:
   - TOXENV=flake8
   - TOXENV=isort
-  - TOXENV=py26-1.4
   - TOXENV=py27-1.4
   - TOXENV=py27-1.7
   - TOXENV=py27-1.8
+  - TOXENV=py27-1.9
+  - TOXENV=py27-1.10
   - TOXENV=py27-master
   - TOXENV=py32-1.7
   - TOXENV=py32-1.8
@@ -16,6 +17,8 @@ env:
   - TOXENV=py33-1.8
   - TOXENV=py34-1.7
   - TOXENV=py34-1.8
+  - TOXENV=py34-1.9
+  - TOXENV=py34-1.10
   - TOXENV=py34-master
 
 matrix:
@@ -25,7 +28,7 @@ matrix:
     - env: TOXENV=py34-master
 
 install:
-  - pip install tox coveralls
+  - pip install tox coveralls "virtualenv<14.0"
 
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
     flake8,
-    py26-1.4,
-    py27-{1.4,1.7,1.8,master},
+    py27-{1.4,1.7,1.8,1.9,1.10,master},
     py32-{1.7,1.8},
     py33-{1.7,1.8},
-    py34-{1.7,1.8,master}
+    py34-{1.7,1.8,1.9,1.10,master}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py32: python3.2
     py33: python3.3
@@ -19,11 +17,14 @@ commands =
     {envpython} -R -Wonce {envbindir}/coverage run {envbindir}/django-admin.py test  --pythonpath=. --settings test_settings picklefield
     coverage report
 deps =
-    coverage
+    py32: coverage<4.0
+    {py27,py33,py34,py35}: coverage
     1.4: Django>=1.4,<1.5
     1.4: South
     1.7: Django>=1.7,<1.8
     1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
+    1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:flake8]


### PR DESCRIPTION
`Virtualenv` dropped support for Python 3.2, so CI tests won't work.