### PR TITLE
Removed Python 2.6 from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
Python 2.6 support was dropped in 855e1a77e51620858df8982d070c071fa49c8865.