### PR TITLE
Allow skipping the copy step of encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,41 @@
-sudo: no
-
+sudo: false
 language: python
-
-env:
-  - TOXENV=flake8
-  - TOXENV=isort
-  - TOXENV=py27-1.4
-  - TOXENV=py27-1.7
-  - TOXENV=py27-1.8
-  - TOXENV=py27-1.9
-  - TOXENV=py27-1.10
-  - TOXENV=py27-1.11
-  - TOXENV=py32-1.7
-  - TOXENV=py32-1.8
-  - TOXENV=py33-1.7
-  - TOXENV=py33-1.8
-  - TOXENV=py34-1.7
-  - TOXENV=py34-1.8
-  - TOXENV=py34-1.9
-  - TOXENV=py34-1.10
-  - TOXENV=py34-1.11
-  - TOXENV=py34-master
-
 matrix:
+  include:
+    - env: TOXENV=flake8
+    - env: TOXENV=isort
+    - env: TOXENV=py27-1.8
+    - env: TOXENV=py27-1.9
+    - env: TOXENV=py27-1.10
+    - env: TOXENV=py27-1.11
+    - env: TOXENV=py33-1.8
+      python: 3.3
+    - env: TOXENV=py34-1.8
+      python: 3.4
+    - env: TOXENV=py34-1.9
+      python: 3.4
+    - env: TOXENV=py34-1.10
+      python: 3.4
+    - env: TOXENV=py34-1.11
+      python: 3.4
+    - env: TOXENV=py34-master
+      python: 3.4
+    - env: TOXENV=py35-1.11
+      python: 3.5
+    - env: TOXENV=py35-master
+      python: 3.5
+    - env: TOXENV=py36-1.11
+      python: 3.6
+    - env: TOXENV=py36-master
+      python: 3.6
   fast_finish: true
   allow_failures:
     - env: TOXENV=py34-master
+      python: 3.4
+    - env: TOXENV=py35-master
+      python: 3.5
+    - env: TOXENV=py36-master
+      python: 3.6
 
 install:
   - pip install tox coveralls "virtualenv<14.0"

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,10 @@ Changes in version 0.3.3
 ========================
 
 * Added a new option to prevent a copy of the object before pickling: `copy=True`
+* Dropped support for Django 1.4
+* Dropped support for Django 1.7
+* Dropped support for Python 3.2
+* Added support for Python 3.6
 
 Changes in version 0.3.2
 ========================

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,12 @@ base64-encoded pickles, which allows reliable deserialization, but such a
 format is not convenient for parsing in the browser.  By overriding
 ``value_to_string()`` you can choose a more convenient serialization format.
 
+Fields now accept the boolean key word argument `copy`, which defaults to
+`True`. The `copy` is necessary for lookups to work correctly. If you don't
+care about performing lookups on the picklefield, you can set `copy=False` to
+save on some memory usage. This an be especially beneficial for very large
+object trees.
+
 -------------
 Running tests
 -------------
@@ -130,6 +136,11 @@ since it is never a good idea to have a PickledObjectField be user editable.
 -------
 Changes
 -------
+
+Changes in version 0.3.3
+========================
+
+* Added a new option to prevent a copy of the object before pickling: `copy=True`
 
 Changes in version 0.3.2
 ========================

--- a/src/picklefield/fields.py
+++ b/src/picklefield/fields.py
@@ -172,12 +172,3 @@ class PickledObjectField(_PickledObjectField):
         if lookup_name not in ['exact', 'in', 'isnull']:
             raise TypeError('Lookup type %s is not supported.' % lookup_name)
         return super(PickledObjectField, self).get_lookup(lookup_name)
-
-
-# South support; see http://south.aeracode.org/docs/tutorial/part4.html#simple-inheritance
-try:
-    from south.modelsinspector import add_introspection_rules
-except ImportError:
-    pass
-else:
-    add_introspection_rules([], [r"^picklefield\.fields\.PickledObjectField"])

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,25 @@
 [tox]
 envlist =
     flake8,
-    py27-{1.4,1.7,1.8,1.9,1.10,1.11},
-    py32-{1.7,1.8},
-    py33-{1.7,1.8},
-    py34-{1.7,1.8,1.9,1.10,1.11,master}
+    py27-{1.8,1.9,1.10,1.11},
+    py33-{1.8},
+    py34-{1.8,1.9,1.10,1.11,master}
+    py35-{1.8,1.9,1.10,1.11,master}
+    py36-{1.11,master}
 
 [testenv]
 basepython =
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
+    py35: python3.5
+    py36: python3.6
 usedevelop = true
 commands =
     {envpython} -R -Wonce {envbindir}/coverage run {envbindir}/django-admin.py test  --pythonpath=. --settings test_settings picklefield
     coverage report
 deps =
-    py32: coverage<4.0
-    {py27,py33,py34,py35}: coverage
-    1.4: Django>=1.4,<1.5
-    1.4: South
-    1.7: Django>=1.7,<1.8
+    coverage
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
@@ -33,11 +31,11 @@ basepython = python2.7
 commands =
     flake8
 deps =
-    flake8==2.4.1
+    flake8==3.3.0
 
 [testenv:isort]
 basepython = python2.7
 commands =
     isort --recursive --check-only --diff src/picklefield
 deps =
-    isort==4.1.2
+    isort==4.2.5


### PR DESCRIPTION
I've also dropped tox testing for unsupported django and python versions, while adding in python 3.6 testing. I'm not terribly concerned about the supported versions, but figured I'd do some cleanup while I was there. I can remove that specific commit if you'd prefer to leave the versions alone.