### PR TITLE
Added Joblib pickle methods

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
 [run]
 source = picklefield
 branch = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    noqa

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ django_picklefield.egg-info/*
 build/
 .coverage
 .tox
+*.sw[pon]

--- a/picklefield/__init__.py
+++ b/picklefield/__init__.py
@@ -3,9 +3,10 @@ from __future__ import unicode_literals
 import django.utils.version
 
 from .constants import DEFAULT_PROTOCOL
-from .fields import PickledObjectField
+from .fields import PickledObjectField, JobLibPickledObjectField
 
-__all__ = 'VERSION', '__version__', 'DEFAULT_PROTOCOL', 'PickledObjectField'
+__all__ = 'VERSION', '__version__', 'DEFAULT_PROTOCOL', 'PickledObjectField', \
+    'JobLibPickledObjectField'
 
 VERSION = (2, 0, 0, 'alpha', 0)
 

--- a/picklefield/__init__.py
+++ b/picklefield/__init__.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import django.utils.version
 
 from .constants import DEFAULT_PROTOCOL
-from .fields import PickledObjectField, JobLibPickledObjectField
+from .fields import JobLibPickledObjectField, PickledObjectField
 
 __all__ = 'VERSION', '__version__', 'DEFAULT_PROTOCOL', 'PickledObjectField', \
     'JobLibPickledObjectField'

--- a/picklefield/fields.py
+++ b/picklefield/fields.py
@@ -18,7 +18,7 @@ except ImportError:
     from pickle import loads, dumps
 try:
     from joblib import load as jobload, dump as jobdump
-except ImportError:
+except ImportError:  # noqa
     jobload = jobdump = None
 
 
@@ -240,6 +240,8 @@ class JobLibPickledObjectField(BasePickledObjectField):
     use the ``isnull`` lookup type correctly.
     """
     def encode(self, value):
+        if self.copy:
+            value = deepcopy(value)
         fileobj = BytesIO()
         jobdump(value, fileobj, self.compress)
         fileobj.seek(0)
@@ -250,7 +252,6 @@ class JobLibPickledObjectField(BasePickledObjectField):
     def decode(self, value):
         value = value.encode()
         value = b64decode(value)
-
         fileobj = BytesIO(value)
         obj = jobload(fileobj, self.compress)
         return obj

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=['Django>=1.11'],
     extras_require={
-        'tests': ['tox'],
+        'tests': ['tox', 'joblib'],
     },
 )

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 
 from django.db import models
-from picklefield import PickledObjectField
+from picklefield import PickledObjectField, JobLibPickledObjectField
 
 S1 = 'Hello World'
 T1 = (1, 2, 3, 4, 5)
@@ -31,3 +31,7 @@ class TestingModel(models.Model):
 
 class MinimalTestingModel(models.Model):
     pickle_field = PickledObjectField()
+
+
+class JobLibModel(models.Model):
+    joblib_field = JobLibPickledObjectField()

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 
 from django.db import models
-from picklefield import PickledObjectField, JobLibPickledObjectField
+from picklefield import JobLibPickledObjectField, PickledObjectField
 
 S1 = 'Hello World'
 T1 = (1, 2, 3, 4, 5)
@@ -33,5 +33,13 @@ class MinimalTestingModel(models.Model):
     pickle_field = PickledObjectField()
 
 
-class JobLibModel(models.Model):
-    joblib_field = JobLibPickledObjectField()
+class JobLibTestingModel(models.Model):
+    pickle_field = JobLibPickledObjectField()
+    compressed_pickle_field = JobLibPickledObjectField(compress=True)
+    default_pickle_field = JobLibPickledObjectField(default=(D1, S1, T1, L1))
+    callable_pickle_field = JobLibPickledObjectField(default=date.today)
+    non_copying_field = JobLibPickledObjectField(copy=False, default=TestCopyDataType('boom!'))
+
+
+class JobLibMinimalModel(models.Model):
+    pickle_field = JobLibPickledObjectField()

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ commands =
     coverage report
 deps =
     coverage
+    joblib
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1
     2.1: Django>=2.1,<2.2


### PR DESCRIPTION
Thank for this project.

I needed to use the joblib pickle methods for numpy/pandas/scikit-learn.
As explained [here](https://scikit-learn.org/stable/tutorial/basic/tutorial.html#model-persistence), this method is more efficient for this kind of object.

So:
- I added a `JobLibPickledObjectField`
- I created `BasePickledObjectField`which is the parent class of `PickledObjectField` and `JobLibPickledObjectField`
- I subclassed the existing `PickledObjectFieldCheckTests` to create `JobLibPickledObjectFieldCheckTests `

In few words, the existing API isn't changed, and the new field has the same behavior than the old one.