### PR TITLE
Updated DEFAULT_PROTOCOL to 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 cache: pip
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,8 @@ UNRELEASED
 ==========
 
 * Dropped support for Python 2.
+* Updated default pickle protocol to version 3.
+
 Changes in version 2.1.0
 ========================
 

--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,7 @@ UNRELEASED
 
 * Dropped support for Python 2.
 * Updated default pickle protocol to version 3.
+* Added testing against Django 3.0.
 * Dropped support for Django 1.11.
 
 Changes in version 2.1.0

--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,10 @@ since it is never a good idea to have a PickledObjectField be user editable.
 Changes
 -------
 
+UNRELEASED
+==========
+
+* Dropped support for Python 2.
 Changes in version 2.1.0
 ========================
 

--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,7 @@ UNRELEASED
 
 * Dropped support for Python 2.
 * Updated default pickle protocol to version 3.
+* Dropped support for Django 1.11.
 
 Changes in version 2.1.0
 ========================

--- a/picklefield/constants.py
+++ b/picklefield/constants.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-DEFAULT_PROTOCOL = 2
+DEFAULT_PROTOCOL = 3

--- a/picklefield/fields.py
+++ b/picklefield/fields.py
@@ -31,7 +31,7 @@ class PickledObject(str):
     """
 
 
-class _ObjectWrapper(object):
+class _ObjectWrapper:
     """
     A class used to wrap object that have properties that may clash with the
     ORM internals.
@@ -95,7 +95,7 @@ class PickledObjectField(models.Field):
         self.protocol = kwargs.pop('protocol', DEFAULT_PROTOCOL)
         self.copy = kwargs.pop('copy', True)
         kwargs.setdefault('editable', False)
-        super(PickledObjectField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_default(self):
         """
@@ -114,7 +114,7 @@ class PickledObjectField(models.Field):
                 return self.default()
             return self.default
         # If the field doesn't have a default, then we punt to models.Field.
-        return super(PickledObjectField, self).get_default()
+        return super().get_default()
 
     def _check_default(self):
         if self.has_default() and isinstance(self.default, (list, dict, set)):
@@ -139,7 +139,7 @@ class PickledObjectField(models.Field):
             return []
 
     def check(self, **kwargs):
-        errors = super(PickledObjectField, self).check(**kwargs)
+        errors = super().check(**kwargs)
         errors.extend(self._check_default())
         return errors
 
@@ -167,7 +167,7 @@ class PickledObjectField(models.Field):
         return value
 
     def pre_save(self, model_instance, add):
-        value = super(PickledObjectField, self).pre_save(model_instance, add)
+        value = super().pre_save(model_instance, add)
         return wrap_conflictual_object(value)
 
     if DJANGO_VERSION < (2, 0):
@@ -211,4 +211,4 @@ class PickledObjectField(models.Field):
         """
         if lookup_name not in ['exact', 'in', 'isnull']:
             raise TypeError('Lookup type %s is not supported.' % lookup_name)
-        return super(PickledObjectField, self).get_lookup(lookup_name)
+        return super().get_lookup(lookup_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ combine_as_imports=true
 include_trailing_comma=true
 multi_line_output=5
 not_skip=__init__.py
-
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
@@ -39,6 +38,7 @@ setup(
     ],
     keywords=['django pickle model field'],
     packages=find_packages(exclude=['tests', 'tests.*']),
+    python_requires='>=3',
     install_requires=['Django>=1.11'],
     extras_require={
         'tests': ['tox'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,12 @@ args_are_paths = false
 envlist =
     flake8,
     isort,
-    py27-1.11,
     py35-{1.11,2.2},
     py36-{1.11,2.2,3.0,master},
     py37-{1.11,2.2,3.0,master},
     py38-{2.2,3.0,master},
 
 [tox:travis]
-2.7 = py27
 3.5 = py35
 3.6 = py36
 3.7 = py37
@@ -19,7 +17,6 @@ envlist =
 
 [testenv]
 basepython =
-    py27: python2.7
     py35: python3.5
     py36: python3.6
     py37: python3.7
@@ -29,7 +26,6 @@ commands =
     {envpython} -R -Wonce {envbindir}/coverage run --branch -m django test -v2 --settings=tests.settings {posargs}
     coverage report -m
 deps =
-    py27: mock
     coverage
     1.11: Django>=1.11,<2.0
     2.0: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -33,12 +33,12 @@ deps =
 
 [testenv:flake8]
 usedevelop = false
-basepython = python2.7
+basepython = python3.6
 commands = flake8
 deps = flake8
 
 [testenv:isort]
 usedevelop = false
-basepython = python2.7
+basepython = python3.6
 commands = isort --recursive --check-only --diff picklefield tests
 deps = isort==4.2.5

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ args_are_paths = false
 envlist =
     flake8,
     isort,
-    py35-{1.11,2.2},
-    py36-{1.11,2.2,3.0,master},
-    py37-{1.11,2.2,3.0,master},
+    py35-2.2,
+    py36-{2.2,3.0,master},
+    py37-{2.2,3.0,master},
     py38-{2.2,3.0,master},
 
 [tox:travis]
@@ -27,9 +27,6 @@ commands =
     coverage report -m
 deps =
     coverage
-    1.11: Django>=1.11,<2.0
-    2.0: Django>=2.0,<2.1
-    2.1: Django>=2.1,<2.2
     2.2: Django>=2.2,<3.0
     3.0: Django>=3.0,<3.1
     master: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
> Protocol version 3 was added in Python 3.0. It has explicit support for bytes objects and cannot be unpickled by Python 2.x. This was the default protocol in Python 3.0–3.7.

Not sure it dropping PY2 is on the cards now that it's EOL but, if so I think it would be fair to bump the default protocol version. 

**WIP** because they'll be lots that breaks on tox/travis. I will check back on that later. 