### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ python:
 stages:
   - lint
   - test
+arch:
+  - amd64
+  - ppc64le
 jobs:
   fast_finish: true
   include:
     - { stage: lint, env: TOXENV=flake8, python: 3.6 }
     - { stage: lint, env: TOXENV=isort, python: 3.6 }
+    - { stage: lint, env: TOXENV=flake8, python: 3.6, arch: ppc64le }
+    - { stage: lint, env: TOXENV=isort, python: 3.6, arch: ppc64le }
 
 install:
 - pip install tox coveralls tox-travis


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-picklefield/builds/188998356

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj