### PR TITLE
Add custom loads and dumps settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ django_picklefield.egg-info/*
 build/
 .coverage
 .tox
+.tool-versions

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,21 @@ and assign whatever you like (as long as it's picklable) to the field:
     >>> obj.args = ['fancy', {'objects': 'inside'}]
     >>> obj.save()
 
+--------
+Settings
+--------
+
+`PICKLEFIELD_DEFAULT_PROTOCOL`
+
+Set the default pickle protocol on dumps encoding
+
+`PICKLEFIELD_DUMPS`
+
+Path to a dumps function, defaults to `pickle.dumps`
+
+`PICKLEFIELD_LOADS`
+
+Path to a loads function, defaults to `pickle.loads`
 
 -----
 Notes

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from django.db import models
+
 from picklefield import PickledObjectField
 
 S1 = 'Hello World'

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
     flake8,
     isort,
     py35-2.2,
-    py36-{2.2,3.0,master},
-    py37-{2.2,3.0,master},
-    py38-{2.2,3.0,master},
+    py36-{2.2,3.0,main},
+    py37-{2.2,3.0,main},
+    py38-{2.2,3.0,main},
 
 [tox:travis]
 3.5 = py35
@@ -29,7 +29,7 @@ deps =
     coverage
     2.2: Django>=2.2,<3.0
     3.0: Django>=3.0,<3.1
-    master: https://github.com/django/django/archive/master.tar.gz
+    master: https://github.com/django/django/archive/main.tar.gz
 
 [testenv:flake8]
 usedevelop = false


### PR DESCRIPTION
This allows me to customize the `loads` and `dumps` via settings to use [dill](https://pypi.org/project/dill/) instead of the default pickle. If no setting exists, defaults to `pickle.loads` and `pickle.dumps`

eg.

```python
# settings.py
PICKLEFIELD_DUMPS = 'dill.dumps'
PICKLEFIELD_LOADS = 'dill.loads'
```