### PR TITLE
Add AutoField primary key in test models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ django_picklefield.egg-info/*
 build/
 .coverage
 .tox
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 stages:
   - lint
   - test
@@ -16,10 +17,10 @@ arch:
 jobs:
   fast_finish: true
   include:
-    - { stage: lint, env: TOXENV=flake8, python: 3.6 }
-    - { stage: lint, env: TOXENV=isort, python: 3.6 }
-    - { stage: lint, env: TOXENV=flake8, python: 3.6, arch: ppc64le }
-    - { stage: lint, env: TOXENV=isort, python: 3.6, arch: ppc64le }
+    - { stage: lint, env: TOXENV=flake8, python: 3.9 }
+    - { stage: lint, env: TOXENV=isort, python: 3.9 }
+    - { stage: lint, env: TOXENV=flake8, python: 3.9, arch: ppc64le }
+    - { stage: lint, env: TOXENV=isort, python: 3.9, arch: ppc64le }
 
 install:
 - pip install tox coveralls tox-travis
@@ -36,4 +37,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    condition: "$TRAVIS_PYTHON_VERSION = 3.5"
+    condition: "$TRAVIS_PYTHON_VERSION = 3.9"

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,21 +10,21 @@ D1 = {1: 1, 2: 4, 3: 6, 4: 8, 5: 10}
 D2 = {1: 2, 2: 4, 3: 6, 4: 8, 5: 10}
 
 
-class TestCopyDataType(str):
+class FakeCopyDataType(str):
     def __deepcopy__(self, memo):
         raise ValueError('Please dont copy me')
 
 
-class TestCustomDataType(str):
+class FakeCustomDataType(str):
     pass
 
 
-class TestingModel(models.Model):
+class FakeModel(models.Model):
     pickle_field = PickledObjectField()
     compressed_pickle_field = PickledObjectField(compress=True)
     default_pickle_field = PickledObjectField(default=(D1, S1, T1, L1))
     callable_pickle_field = PickledObjectField(default=date.today)
-    non_copying_field = PickledObjectField(copy=False, default=TestCopyDataType('boom!'))
+    non_copying_field = PickledObjectField(copy=False, default=FakeCopyDataType('boom!'))
     nullable_pickle_field = PickledObjectField(null=True)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
     flake8,
     isort,
     py35-2.2,
-    py36-{2.2,3.2,master},
-    py37-{2.2,3.2,4.0,master},
-    py38-{2.2,3.2,4.0,master},
-    py39-{2.2,3.2,4.0,master},
+    py36-{2.2,3.2,main},
+    py37-{2.2,3.2,4.0,main},
+    py38-{2.2,3.2,4.0,main},
+    py39-{2.2,3.2,4.0,main},
 
 [tox:travis]
 3.5 = py35
@@ -35,7 +35,7 @@ deps =
     2.2: Django>=2.2,<3.0
     3.2: Django>=3.2,<3.3
     4.0: Django>=4.0,<4.1
-    master: https://github.com/django/django/archive/master.tar.gz
+    main: https://github.com/django/django/archive/main.tar.gz
 
 [testenv:flake8]
 usedevelop = false

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,17 @@ envlist =
     flake8,
     isort,
     py35-2.2,
-    py36-{2.2,3.0,master},
-    py37-{2.2,3.0,master},
-    py38-{2.2,3.0,master},
+    py36-{2.2,3.2,master},
+    py37-{2.2,3.2,4.0,master},
+    py38-{2.2,3.2,4.0,master},
+    py39-{2.2,3.2,4.0,master},
 
 [tox:travis]
 3.5 = py35
 3.6 = py36
 3.7 = py37
 3.8 = py38
+3.9 = py39
 
 [testenv]
 basepython =
@@ -21,24 +23,28 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 usedevelop = true
 commands =
-    {envpython} -R -Wonce {envbindir}/coverage run --branch -m django test -v2 --settings=tests.settings {posargs}
+    {envpython} -R -Wonce {envbindir}/coverage run --branch -m pytest --ds tests.settings tests/tests.py {posargs}
     coverage report -m
 deps =
+    pytest
+    pytest-django
     coverage
     2.2: Django>=2.2,<3.0
-    3.0: Django>=3.0,<3.1
+    3.2: Django>=3.2,<3.3
+    4.0: Django>=4.0,<4.1
     master: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:flake8]
 usedevelop = false
-basepython = python3.6
+basepython = python3.9
 commands = flake8
 deps = flake8
 
 [testenv:isort]
 usedevelop = false
-basepython = python3.6
+basepython = python3.9
 commands = isort --recursive --check-only --diff picklefield tests
 deps = isort==4.2.5


### PR DESCRIPTION
Moved to pytest
Set default python to 3.9
Add AutoField primary key to avoid Django 3.2+ warnings